### PR TITLE
Fix linux launchers by downgrading to `ubuntu-20.04`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -12,7 +12,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu-latest, windows-latest, macos-latest]
+        os: [ubuntu-20.04, windows-latest, macos-latest]
     steps:
       - uses: actions/checkout@v2
         with:
@@ -47,7 +47,7 @@ jobs:
           UPLOAD_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-static-launcher:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -75,7 +75,7 @@ jobs:
           UPLOAD_GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
   generate-mostly-static-launcher:
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:
@@ -105,7 +105,7 @@ jobs:
   publish:
     needs: generate-launchers
     if: github.event_name == 'push'
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-20.04
     steps:
       - uses: actions/checkout@v2
         with:


### PR DESCRIPTION
```
Downloading https://github.com/VirtusLab/java-class-name/releases/download/v0.1.1/java-class-name-x86_64-pc-linux.gz
Downloaded https://github.com/VirtusLab/java-class-name/releases/download/v0.1.1/java-class-name-x86_64-pc-linux.gz
/home/runner/.cache/coursier/arc/https/github.com/VirtusLab/java-class-name/releases/download/v0.1.1/java-class-name-x86_64-pc-linux.gz/java-class-name-x86_64-pc-linux: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.32' not found (required by /home/runner/.cache/coursier/arc/https/github.com/VirtusLab/java-class-name/releases/download/v0.1.1/java-class-name-x86_64-pc-linux.gz/java-class-name-x86_64-pc-linux)
/home/runner/.cache/coursier/arc/https/github.com/VirtusLab/java-class-name/releases/download/v0.1.1/java-class-name-x86_64-pc-linux.gz/java-class-name-x86_64-pc-linux: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.34' not found (required by /home/runner/.cache/coursier/arc/https/github.com/VirtusLab/java-class-name/releases/download/v0.1.1/java-class-name-x86_64-pc-linux.gz/java-class-name-x86_64-pc-linux)
Exception in thread "main" os.SubprocessException: Result of /home/runner/.cache/coursier/arc/https/github.com/VirtusLab/java-class-name/releases/download/v0.1.1/java-class-name-x86_64-pc-linux.gz/java-class-name-x86_64-pc-linux…: 1
```
Our linux launchers seem to be broken because of `glibc`, this should do the trick.