### PR TITLE
Fix `jline` transitive deps

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -93,11 +93,12 @@ trait JavaClassNameModule extends ScalaModule with ScalafixModule {
 
   override def allIvyDeps: Target[Agg[Dep]] = Task {
     super.allIvyDeps()
-      .map(_.exclude(jlineOrg -> "jline-*")) ++ jlineDeps
+      .map(_.exclude(jlineDeps.toSeq.map(d => d.organization -> d.name): _*)) ++ jlineDeps
   }
 
   override def ivyDeps: Target[Agg[Dep]] =
-    super.ivyDeps().map(_.exclude("org.jline" -> "jline-*")) ++ jlineDeps
+    super.ivyDeps().map(_.exclude(jlineDeps.toSeq
+      .map(d => d.organization -> d.name): _*)) ++ jlineDeps
 }
 
 object `scala3-graal-processor` extends JavaClassNameModule {


### PR DESCRIPTION
This should address the failures in the Scala CLI bump:
- https://github.com/VirtusLab/scala-cli/pull/3674
```
Error: Could not find option 'UnlockExperimentalVMOptions' from 'jar:file:///Users/runner/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-terminal-jni/3.27.1/jline-terminal-jni-3.27.1.jar!/META-INF/native-image/org.jline/jline-terminal-jni/native-image.properties'. Use -H:PrintFlags= to list all available options.
Could not find option 'UnlockExperimentalVMOptions' from 'jar:file:///Users/runner/Library/Caches/Coursier/v1/https/repo1.maven.org/maven2/org/jline/jline-native/3.27.1/jline-native-3.27.1.jar!/META-INF/native-image/org.jline/jline-native/native-image.properties'. Use -H:PrintFlags= to list all available options.
```
